### PR TITLE
Environment files

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
       updated: ${{ steps.versionist.outputs.updated }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       updated: ${{ steps.versionist.outputs.updated }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker buildx

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,9 +83,9 @@ function run_versionist () {
     fi
   fi
 
-  # Set outputs
-  echo "::set-output name=version::$(get_version)"
-  echo "::set-output name=updated::true"
+  # Set environment files
+  echo "version=$(get_version)" >> $VERSIONIST_VERSION
+  echo "updated=true" >> $VERSIONIST_UPDATED
 }
 
 # Defaults
@@ -116,7 +116,8 @@ else
   echo "Commiting changes: No"
 fi
 
-echo "::set-output name=version::$(get_version)"
-echo "::set-output name=updated::false"
+# Set environment files
+echo "version=$(get_version)" >> $VERSIONIST_VERSION
+echo "updated=false" >> $VERSIONIST_UPDATED
 
 run_versionist $@


### PR DESCRIPTION
Features:
- Added support for environment files instead of outputs (See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

FIxes:
- Updated `actions/checkout` to v3